### PR TITLE
add fine-grained token format

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -467,8 +467,8 @@ export async function activate(context: vscode.ExtensionContext) {
 				if (!value || value.trim() === '') {
 					return 'Token cannot be empty';
 				}
-				if (!value.startsWith('ghp_') && !value.startsWith('gho_') && !value.startsWith('ghu_')) {
-					return 'Invalid token format. GitHub tokens typically start with ghp_, gho_, or ghu_';
+				if (!value.startsWith('ghp_') && !value.startsWith('gho_') && !value.startsWith('ghu_') && !value.startsWith('github_pat_')) {
+					return 'Invalid token format. GitHub tokens typically start with ghp_, gho_, ghu_, or github_pat_';
 				}
 				return null;
 			}


### PR DESCRIPTION
This pull request makes a small update to the token validation logic in the `activate` function. The change expands the accepted GitHub token formats to include tokens starting with `github_pat_` -- the format for a fine-grained personal access token.

Haven't added the other formats, because I'm not sure if they follow the repository owner's intent. But I hope the fine-grained PAT is ok!

Reference: [GitHub's token formats](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github#githubs-token-formats)